### PR TITLE
Устранена проблема возникновения blankscreen при удалении сервера

### DIFF
--- a/config/translations/be/strings.xml
+++ b/config/translations/be/strings.xml
@@ -123,6 +123,7 @@
     <string name="scan_qr">Сканаваць QR-код</string>
 
     <!-- Server detail -->
+    <string name="server_not_found">Гэтага сервера ўжо няма ў спісе. Націсніце «Назад», каб вярнуцца.</string>
     <string name="server_section">Сервер</string>
     <string name="name">Імя</string>
     <string name="country">Краіна</string>

--- a/config/translations/en/strings.xml
+++ b/config/translations/en/strings.xml
@@ -123,6 +123,7 @@
     <string name="scan_qr">Scan QR code</string>
 
     <!-- Server detail -->
+    <string name="server_not_found">This server is no longer in the list. Tap Back to return.</string>
     <string name="server_section">Server</string>
     <string name="name">Name</string>
     <string name="country">Country</string>

--- a/config/translations/ru/strings.xml
+++ b/config/translations/ru/strings.xml
@@ -123,6 +123,7 @@
     <string name="scan_qr">Сканировать QR-код</string>
 
     <!-- Server detail -->
+    <string name="server_not_found">Этого сервера уже нет в списке. Нажмите «Назад», чтобы вернуться.</string>
     <string name="server_section">Сервер</string>
     <string name="name">Имя</string>
     <string name="country">Страна</string>

--- a/config/translations/tt/strings.xml
+++ b/config/translations/tt/strings.xml
@@ -71,6 +71,7 @@
     <string name="or_add_existing">яки булган серверны өстәгез</string>
     <string name="enter_smart_key">Смарт-ачкыч кертү</string>
     <string name="scan_qr">QR-код сканерлау</string>
+    <string name="server_not_found">Бу сервер исемлектә юк инде. Кайту өчен «Кайту» төймәсенә басыгыз.</string>
     <string name="server_section">Сервер</string>
     <string name="name">Исем</string>
     <string name="country">Ил</string>

--- a/mobile/android/app/src/main/java/com/lionheart/vpn/MainActivity.kt
+++ b/mobile/android/app/src/main/java/com/lionheart/vpn/MainActivity.kt
@@ -95,7 +95,15 @@ fun LionheartNavigation(vm: VpnViewModel, onRequestVpnPermission: () -> Unit) {
             ServerDetailScreen(
                 vm = vm,
                 serverId = serverId,
-                onBack = { navController.popBackStack() },
+                onBack = {
+                    // Явно возвращаемся к home (снимает server_detail и split_tunnel над ним), без второго лишнего pop.
+                    if (!navController.popBackStack("home", inclusive = false)) {
+                        navController.navigate("home") {
+                            popUpTo(navController.graph.startDestinationId) { inclusive = true }
+                            launchSingleTop = true
+                        }
+                    }
+                },
                 onNavigateSplitTunnel = { id -> navController.navigate("split_tunnel/$id") }
             )
         }

--- a/mobile/android/app/src/main/java/com/lionheart/vpn/ui/screens/ServerDetailScreen.kt
+++ b/mobile/android/app/src/main/java/com/lionheart/vpn/ui/screens/ServerDetailScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.lionheart.vpn.R
 import com.lionheart.vpn.data.ServerProfile
@@ -30,7 +31,27 @@ fun ServerDetailScreen(
 ) {
     val servers by vm.servers.collectAsState()
     val server = servers.find { it.id == serverId }
-    if (server == null) { LaunchedEffect(Unit) { onBack() }; return }
+    if (server == null) {
+        // Не вызывать onBack() из LaunchedEffect: после удаления колбэк уже делает popBackStack;
+        // повторный pop снимает home → пустой NavHost. Только ручной выход (битый id и т.п.).
+        Column(
+            Modifier.fillMaxSize().padding(24.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                stringResource(R.string.server_not_found),
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(20.dp))
+            Button(onClick = onBack, shape = RoundedCornerShape(14.dp)) {
+                Text(stringResource(R.string.back))
+            }
+        }
+        return
+    }
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showUninstallDialog by remember { mutableStateOf(false) }
     var showDnsDialog by remember { mutableStateOf(false) }
@@ -184,7 +205,12 @@ fun ServerDetailScreen(
             onDismissRequest = { showDeleteDialog = false },
             title = { Text(stringResource(R.string.delete_server_confirm)) },
             text = { Text(stringResource(R.string.delete_server_msg, server.name)) },
-            confirmButton = { TextButton(onClick = { vm.removeServer(serverId); showDeleteDialog = false; onBack() }) { Text(stringResource(R.string.delete), color = MaterialTheme.colorScheme.error) } },
+            confirmButton = {
+                TextButton(onClick = {
+                    showDeleteDialog = false
+                    vm.removeServer(serverId) { onBack() }
+                }) { Text(stringResource(R.string.delete), color = MaterialTheme.colorScheme.error) }
+            },
             dismissButton = { TextButton(onClick = { showDeleteDialog = false }) { Text(stringResource(R.string.cancel)) } }
         )
     }

--- a/mobile/android/app/src/main/java/com/lionheart/vpn/viewmodel/VpnViewModel.kt
+++ b/mobile/android/app/src/main/java/com/lionheart/vpn/viewmodel/VpnViewModel.kt
@@ -141,23 +141,30 @@ class VpnViewModel(application: Application) : AndroidViewModel(application) {
         } catch (_: Exception) {}
         _showAddKeyDialog.value = false
     }
-    fun removeServer(id: String) {
-        viewModelScope.launch {
-            try {
-                serverRepo.removeServer(id)
-                if (activeServerId.value == id) {
-                    val remaining = serverRepo.servers.first()
-                    if (remaining.isNotEmpty()) {
-                        serverRepo.setActive(remaining.first().id)
-                    } else {
-                        prefs.setSmartKey("")
-                        prefs.setServerIP("")
-                        prefs.setActiveServerId("")
-                    }
+    /** Удаление из списка + сброс активного сервера / prefs (общая логика для «удалить из приложения» и uninstall). */
+    private suspend fun performRemoveServer(id: String) {
+        val wasActive = activeServerId.value == id
+        withContext(Dispatchers.IO) {
+            serverRepo.removeServer(id)
+            if (wasActive) {
+                val remaining = serverRepo.servers.first()
+                if (remaining.isNotEmpty()) {
+                    serverRepo.setActive(remaining.first().id)
+                } else {
+                    prefs.setSmartKey("")
+                    prefs.setServerIP("")
+                    prefs.setActiveServerId("")
                 }
-            } catch (e: Exception) {
-                addLog("error", "removeServer: ${e.message}")
             }
+        }
+    }
+
+    fun removeServer(id: String, onDone: (() -> Unit)? = null) = viewModelScope.launch {
+        try {
+            performRemoveServer(id)
+            onDone?.invoke()
+        } catch (e: Exception) {
+            addLog("error", "removeServer: ${e.message}")
         }
     }
     fun updateServerSetting(id: String, transform: (ServerProfile) -> ServerProfile) = viewModelScope.launch {
@@ -175,14 +182,14 @@ class VpnViewModel(application: Application) : AndroidViewModel(application) {
     fun uninstallServer(id: String, sshPassword: String, onDone: () -> Unit) = viewModelScope.launch {
         try {
             val server = serverRepo.getById(id) ?: return@launch
-            ServerInstaller().uninstall(server.serverIP, server.sshPort, server.sshUser, sshPassword) { _setupState.value = it }.fold(
-                onSuccess = {
-                    serverRepo.removeServer(id)
-                    _setupState.value = null
-                    withContext(Dispatchers.Main) { onDone() }
-                },
-                onFailure = { e -> _setupState.value = SetupProgress(0, 0, "", error = "Ошибка: ${e.message}") }
-            )
+            val r = ServerInstaller().uninstall(server.serverIP, server.sshPort, server.sshUser, sshPassword) { _setupState.value = it }
+            if (r.isSuccess) {
+                performRemoveServer(id)
+                _setupState.value = null
+                onDone()
+            } else {
+                _setupState.value = SetupProgress(0, 0, "", error = "Ошибка: ${r.exceptionOrNull()?.message ?: "unknown"}")
+            }
         } catch (e: Exception) {
             _setupState.value = SetupProgress(0, 0, "", error = "Ошибка: ${e.message}")
         }

--- a/mobile/android/app/src/main/res/values-be/strings.xml
+++ b/mobile/android/app/src/main/res/values-be/strings.xml
@@ -123,6 +123,7 @@
     <string name="scan_qr">Сканаваць QR-код</string>
 
     <!-- Server detail -->
+    <string name="server_not_found">Гэтага сервера ўжо няма ў спісе. Націсніце «Назад», каб вярнуцца.</string>
     <string name="server_section">Сервер</string>
     <string name="name">Імя</string>
     <string name="country">Краіна</string>

--- a/mobile/android/app/src/main/res/values-ru/strings.xml
+++ b/mobile/android/app/src/main/res/values-ru/strings.xml
@@ -123,6 +123,7 @@
     <string name="scan_qr">Сканировать QR-код</string>
 
     <!-- Server detail -->
+    <string name="server_not_found">Этого сервера уже нет в списке. Нажмите «Назад», чтобы вернуться.</string>
     <string name="server_section">Сервер</string>
     <string name="name">Имя</string>
     <string name="country">Страна</string>

--- a/mobile/android/app/src/main/res/values-tt/strings.xml
+++ b/mobile/android/app/src/main/res/values-tt/strings.xml
@@ -71,6 +71,7 @@
     <string name="or_add_existing">яки булган серверны өстәгез</string>
     <string name="enter_smart_key">Смарт-ачкыч кертү</string>
     <string name="scan_qr">QR-код сканерлау</string>
+    <string name="server_not_found">Бу сервер исемлектә юк инде. Кайту өчен «Кайту» төймәсенә басыгыз.</string>
     <string name="server_section">Сервер</string>
     <string name="name">Исем</string>
     <string name="country">Ил</string>

--- a/mobile/android/app/src/main/res/values/strings.xml
+++ b/mobile/android/app/src/main/res/values/strings.xml
@@ -123,6 +123,7 @@
     <string name="scan_qr">Scan QR code</string>
 
     <!-- Server detail -->
+    <string name="server_not_found">This server is no longer in the list. Tap Back to return.</string>
     <string name="server_section">Server</string>
     <string name="name">Name</string>
     <string name="country">Country</string>


### PR DESCRIPTION
Устранена проблема возникновения blankscreen при удалении сервера из страницы настроек сервера, добавлен хендлинг ситуации когда сервер null с возможностью ручного возврата. Проблема заключалась в двойном popBackStack который вызывал выпадение в пустой NavHost с пустым экраном, в случае попадания пользователя на страницу невалидного (null) сервера - добавлен вывод сообщения об его отсутствие и кнопка возврата.

Проверено на Android 15.